### PR TITLE
Add missing Linux IOCTL definitions to compile on FreeBSD

### DIFF
--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -28,6 +28,45 @@
 #include <Python.h>
 #include <fuse.h>
 #include <sys/ioctl.h>
+#ifndef _UAPI_ASM_GENERIC_IOCTL_H
+/* Essential IOCTL defitions from Linux /include/uapi/asm-generic/ioctl.h
+   to fix compilation errors on FreeBSD 
+   Mikhail Zakharov <zmey20000@thoo.com> 2018.10.22 */
+
+#define _IOC_NRBITS     8
+#define _IOC_TYPEBITS   8
+
+#ifndef _IOC_SIZEBITS
+# define _IOC_SIZEBITS  14
+#endif
+
+#ifndef _IOC_DIRBITS
+# define _IOC_DIRBITS   2
+#endif
+
+#define _IOC_SIZEMASK   ((1 << _IOC_SIZEBITS)-1)
+#define _IOC_DIRMASK    ((1 << _IOC_DIRBITS)-1)
+
+#define _IOC_NRSHIFT    0
+#define _IOC_TYPESHIFT  (_IOC_NRSHIFT+_IOC_NRBITS)
+#define _IOC_SIZESHIFT  (_IOC_TYPESHIFT+_IOC_TYPEBITS)
+#define _IOC_DIRSHIFT   (_IOC_SIZESHIFT+_IOC_SIZEBITS)
+
+#ifndef _IOC_NONE
+# define _IOC_NONE      0U
+#endif
+
+#ifndef _IOC_WRITE
+# define _IOC_WRITE     1U
+#endif
+
+#ifndef _IOC_READ
+# define _IOC_READ      2U
+#endif
+
+#define _IOC_DIR(nr)            (((nr) >> _IOC_DIRSHIFT) & _IOC_DIRMASK)
+#define _IOC_SIZE(nr)           (((nr) >> _IOC_SIZESHIFT) & _IOC_SIZEMASK)
+#endif
 
 
 #ifndef FUSE_VERSION

--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -29,7 +29,7 @@
 #include <fuse.h>
 #include <sys/ioctl.h>
 #ifndef _UAPI_ASM_GENERIC_IOCTL_H
-/* Essential IOCTL defitions from Linux /include/uapi/asm-generic/ioctl.h
+/* Essential IOCTL definitions from Linux /include/uapi/asm-generic/ioctl.h
    to fix compilation errors on FreeBSD 
    Mikhail Zakharov <zmey20000@thoo.com> 2018.10.22 */
 


### PR DESCRIPTION
Added Linux IOCTL definitions to fix compilation on FreeBSD