### PR TITLE
use bytes objects for read and write data

### DIFF
--- a/example/fioc.py
+++ b/example/fioc.py
@@ -96,7 +96,7 @@ class FiocFS(Fuse):
 
     def __init__(self, *args, **kw):
         Fuse.__init__(self, *args, **kw)
-        self.buf =  ""
+        self.buf =  b""
 
     def resize(self, new_size):
         old_size = len(self.buf)
@@ -106,7 +106,7 @@ class FiocFS(Fuse):
         if new_size < old_size:
             self.buf = self.buf[0:new_size]
         else:
-            self.buf = self.buf + "\x00" * (new_size - old_size)
+            self.buf = self.buf + b"\x00" * (new_size - old_size)
 
         return 0
 

--- a/example/hello.py
+++ b/example/hello.py
@@ -22,7 +22,7 @@ if not hasattr(fuse, '__version__'):
 fuse.fuse_python_api = (0, 2)
 
 hello_path = '/hello'
-hello_str = 'Hello World!\n'
+hello_str = b'Hello World!\n'
 
 class MyStat(fuse.Stat):
     def __init__(self):
@@ -72,7 +72,7 @@ class HelloFS(Fuse):
                 size = slen - offset
             buf = hello_str[offset:offset+size]
         else:
-            buf = ''
+            buf = b''
         return buf
 
 def main():

--- a/example/xmp.py
+++ b/example/xmp.py
@@ -29,7 +29,7 @@ fuse.feature_assert('stateful_files', 'has_init')
 
 
 def flag2mode(flags):
-    md = {os.O_RDONLY: 'r', os.O_WRONLY: 'w', os.O_RDWR: 'w+'}
+    md = {os.O_RDONLY: 'rb', os.O_WRONLY: 'wb', os.O_RDWR: 'wb+'}
     m = md[flags & (os.O_RDONLY | os.O_WRONLY | os.O_RDWR)]
 
     if flags | os.O_APPEND:

--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -517,12 +517,22 @@ read_func(const char *path, char *buf, size_t s, off_t off)
 	PROLOGUE( PYO_CALLWITHFI(fi, read_cb, snK, path, s, off) )
 #endif
 
+
+#if PY_MAJOR_VERSION >= 3
+	if(PyBytes_Check(v)) {
+		if(PyBytes_Size(v) > s)
+			goto OUT_DECREF;
+		memcpy(buf, PyBytes_AsString(v), PyBytes_Size(v));
+		ret = PyBytes_Size(v);
+	}
+#else
 	if(PyString_Check(v)) {
 		if(PyString_Size(v) > s)
 			goto OUT_DECREF;
 		memcpy(buf, PyString_AsString(v), PyString_Size(v));
 		ret = PyString_Size(v);
 	}
+#endif
 
 	EPILOGUE
 }
@@ -536,7 +546,11 @@ static int
 write_func(const char *path, const char *buf, size_t t, off_t off)
 #endif
 {
+#if PY_MAJOR_VERSION >= 3
+	PROLOGUE( PYO_CALLWITHFI(fi, write_cb, sy#K, path, buf, t, off) )
+#else
 	PROLOGUE( PYO_CALLWITHFI(fi, write_cb, ss#K, path, buf, t, off) )
+#endif
 	EPILOGUE
 }
 


### PR DESCRIPTION
This changes the data type for the buffer of the read and write syscalls from string to bytes. On Python 2, this has no effect. On Python 3, it is a breaking change, but fixes a serious usability bug that limits file data to valid UTF-8 data. With these changes, files can contain arbitrary data.

Fixes #13