### PR TITLE
Fix race in xmp.py (Closes: #18)

### DIFF
--- a/example/xmp.py
+++ b/example/xmp.py
@@ -7,6 +7,8 @@
 #    See the file COPYING.
 #
 
+from __future__ import print_function
+
 import os, sys
 from errno import *
 from stat import *


### PR DESCRIPTION
Using os.pread/os.pwrite is the easy and obvious fix, but unfortunately those are not available in Python 2, so fall back to a per file lock.