### PR TITLE
Fix file write under Python 2 in xmp.py

### DIFF
--- a/example/xmp.py
+++ b/example/xmp.py
@@ -190,7 +190,8 @@ class Xmp(Fuse):
                 self.iolock.acquire()
                 try:
                     self.file.seek(offset)
-                    return self.file.write(buf)
+                    self.file.write(buf)
+                    return len(buf)
                 finally:
                     self.iolock.release()
             else:


### PR DESCRIPTION
I broke it with my locking fixes, apparently I only tested reading under
Python 2. (In Python 3 file.write returns the length, so I thought that
was true in Python 2 as well.) Sorry.