### PR TITLE
Fix object leak in open_func()

### DIFF
--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -740,7 +740,7 @@ open_func(const char *path, struct fuse_file_info *fi)
 	}
 
 	ret = 0;
-	goto OUT;
+	goto OUT_DECREF;
 
 	EPILOGUE
 }


### PR DESCRIPTION
Fixes https://github.com/libfuse/python-fuse/issues/25