### PR TITLE
Define PY_SSIZE_T_CLEAN for Python 3.10

### DIFF
--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -25,6 +25,7 @@
 #define FUSE_USE_VERSION 26
 #endif
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <fuse.h>
 #include <sys/ioctl.h>
@@ -1186,7 +1187,7 @@ ioctl_func(const char *path, int cmd, void *arg,
 {
 	char* s;
 	char* input_data;
-	int input_data_size, output_data_size;
+	Py_ssize_t input_data_size, output_data_size;
 
 	input_data = (char*) data;
 	input_data_size = _IOC_SIZE(cmd);


### PR DESCRIPTION
On Python 3.10, `PY_SSIZE_T_CLEAN` must be defined in order to use '#'
formats.  `ioctl_func` needs a slight change to comply with the new
regime.

(Several functions pass `size_t` here, which may be a little dodgy, but
the main point of this change seems to have been to transition from
`int` to `Py_ssize_t`, and at least `size_t` and `Py_ssize_t` have the
same size.)

Closes #41.