### PR TITLE
Do not unilaterally import distutils in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,9 @@
 # part of the icecast project, http://svn.xiph.org/icecast/trunk/shout-python)
 
 try:
-    from setuptools import setup
+    from setuptools import setup, Extension
 except ImportError:
-    from distutils.core import setup
-from distutils.core import Extension
+    from distutils.core import setup, Extension
 import os
 import sys
 


### PR DESCRIPTION
Python 3.12 removed distutils completly, so also attempt to import Extension from setuptools, and if that fails, to import it from distutils.