### PR TITLE
Remove trailing space on files

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -146,7 +146,7 @@ such a program is covered only if its contents constitute a work based
 on the Library (independent of the use of the Library in a tool for
 writing it).  Whether that is true depends on what the Library does
 and what the program that uses the Library does.
-  
+
   1. You may copy and distribute verbatim copies of the Library's
 complete source code as you receive it, in any medium, provided that
 you conspicuously and appropriately publish on each copy an

--- a/FAQ
+++ b/FAQ
@@ -23,11 +23,11 @@ Solutions:
 
 * Enforce the usage of a stabilized API (practically, API 25) with::
 
-    env CFLAGS=-DFUSE_USE_VERSION=25 python setup.py build 
+    env CFLAGS=-DFUSE_USE_VERSION=25 python setup.py build
 
 * Upgrade your FUSE installation. As of writing this, 2.6.0-pre3 is available.
 
-When I use a dedicated file class, how can I tell apart the cases when an instance of it is instantiated from a ``CREATE`` callback and when it's instantiated from an ``OPEN`` callback? 
+When I use a dedicated file class, how can I tell apart the cases when an instance of it is instantiated from a ``CREATE`` callback and when it's instantiated from an ``OPEN`` callback?
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 If your file class is instantiated via ``FUSE_OPEN``, then it's

--- a/INSTALL
+++ b/INSTALL
@@ -3,8 +3,8 @@ REQUIREMENTS:
  - In general, Python 2.3 or newer.
    Version specific notes:
    - 2.4: this is the version the code is developed with, so you can
-     expect this one to work the most smoothly. 
-   - 2.3: in general, it seems to be useable. However, the optparse 
+     expect this one to work the most smoothly.
+   - 2.3: in general, it seems to be useable. However, the optparse
      module of Python 2.3 is out of date. This doesn't have fatal
      consequences, but if you want nice help optput / version info,
      you should either use optparse.py from 2.4 or install a recent

--- a/README.historic
+++ b/README.historic
@@ -37,11 +37,11 @@ Updated 13-Dec-2003 by David McNab <david@rebirthing.co.nz>
 
     - added 'code.leo' file for convenience of those who use the Leo
       code editor (leo.sf.net)
-    
+
     - added support for 'statfs' and 'fsync' methods (refer xmp.py)
 
 Updated Dec 2003 by David McNab <david@rebirthing.co.nz>:
-    
+
     - added support for 'release' events (ie when file gets closed)
     - added __init__ to base class, which picks off parameters and
       stores them as instance attributes:

--- a/README.new_fusepy_api.rst
+++ b/README.new_fusepy_api.rst
@@ -111,7 +111,7 @@ Let's see how these are implemented.
    out of Python's, so raising an exception makes no sense. We could
    wrap some fs methods into format valifiers; currently we don't do
    that.)
-   
+
 
 FUSE and the command line
 -------------------------
@@ -316,7 +316,7 @@ options (which are not understood by the lib, according to the help
 message), and also purges out these from self, so the remainder can be
 safely passed down to FUSE.
 
-.. [#] We can argue that it's not that sad. We just pass on to FUSE 
+.. [#] We can argue that it's not that sad. We just pass on to FUSE
    what we get from the user and that either eats it or blows up. Why
    would we want more sophistication?
 

--- a/example/_find_fuse_parts.py
+++ b/example/_find_fuse_parts.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_MINOR = "%s.%s" % (sys.version_info[0], sys.version_info[1])
 
 ddd = realpath(join(dirname(sys.argv[0]), '..'))
 
-for d in [ddd, '.']: 
+for d in [ddd, '.']:
     for p in glob.glob(join(d, 'build', 'lib.*%s' % PYTHON_MAJOR_MINOR)):
         sys.path.insert(0, p)
 

--- a/example/xmp.py
+++ b/example/xmp.py
@@ -111,7 +111,7 @@ class Xmp(Fuse):
 #    The following utimens method would do the same as the above utime method.
 #    We can't make it better though as the Python stdlib doesn't know of
 #    sub-second preciseness in access/modify times.
-#  
+#
 #    def utimens(self, path, ts_acc, ts_mod):
 #      os.utime("." + path, (ts_acc.tv_sec, ts_mod.tv_sec))
 
@@ -229,11 +229,11 @@ class Xmp(Fuse):
             # Advisory file locking is pretty messy in Unix, and the Python
             # interface to this doesn't make it better.
             # We can't do fcntl(2)/F_GETLK from Python in a platfrom independent
-            # way. The following implementation *might* work under Linux. 
+            # way. The following implementation *might* work under Linux.
             #
             # if cmd == fcntl.F_GETLK:
             #     import struct
-            # 
+            #
             #     lockdata = struct.pack('hhQQi', kw['l_type'], os.SEEK_SET,
             #                            kw['l_start'], kw['l_len'], kw['l_pid'])
             #     ld2 = fcntl.fcntl(self.fd, fcntl.F_GETLK, lockdata)
@@ -242,7 +242,7 @@ class Xmp(Fuse):
             #     res = {}
             #     for i in xrange(len(uld2)):
             #          res[flockfields[i]] = uld2[i]
-            #  
+            #
             #     return fuse.Flock(**res)
 
             # Convert fcntl-ish lock parameters to Python's weird

--- a/fuse.py
+++ b/fuse.py
@@ -454,23 +454,23 @@ class Direntry(FuseStruct):
 class Flock(FuseStruct):
     """
     Class for representing flock structures (cf. fcntl(3)).
-    
+
     It makes sense to give values to the `l_type`, `l_start`,
     `l_len`, `l_pid` attributes (`l_whence` is not used by
     FUSE, see ``fuse.h``).
     """
 
     def __init__(self, name=None, **kw):
-    
+
         self.l_type  = None
         self.l_start = None
         self.l_len   = None
         self.l_pid   = None
- 
+
         kw['name'] = name
         FuseStruct.__init__(self, **kw)
 
- 
+
 class Timespec(FuseStruct):
     """
     Cf. struct timespec in time.h:
@@ -478,10 +478,10 @@ class Timespec(FuseStruct):
     """
 
     def __init__(self, name=None, **kw):
-    
+
         self.tv_sec  = None
         self.tv_nsec = None
- 
+
         kw['name'] = name
         FuseStruct.__init__(self, **kw)
 
@@ -664,13 +664,13 @@ class Fuse(object):
             raise RuntimeError(__name__ + """.fuse_python_api not defined.
 
 ! Please define """ + __name__ + """.fuse_python_api internally (eg.
-! 
+!
 ! (1)  """ + __name__ + """.fuse_python_api = """ + repr(FUSE_PYTHON_API_VERSION) + """
-! 
-! ) or in the enviroment (eg. 
-! 
+!
+! ) or in the enviroment (eg.
+!
 ! (2)  FUSE_PYTHON_API=0.1
-! 
+!
 ! ).
 !
 ! If you are actually developing a filesystem, probably (1) is the way to go.
@@ -684,7 +684,7 @@ class Fuse(object):
             malformed()
         for i in fuse_python_api:
             if not isinstance(i, int) or i < 0:
-                malformed() 
+                malformed()
 
         if fuse_python_api > FUSE_PYTHON_API_VERSION:
             raise RuntimeError("""

--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -450,11 +450,11 @@ dir_add_entry(PyObject *v, fuse_dirh_t buf, fuse_dirfil_t df)
 	fetchattr(&offs, offset);
 
 	if (!(pytmp = PyObject_GetAttrString(v, "name")))
-		goto OUT_DECREF;		
+		goto OUT_DECREF;
 	if (!PyString_Check(pytmp)) {
 		Py_DECREF(pytmp);
-		goto OUT_DECREF;		
-	}					
+		goto OUT_DECREF;
+	}
 
 	char *s;
 	PATH_AS_STR_BEGIN(pytmp, s);
@@ -678,7 +678,7 @@ read_func(const char *path, char *buf, size_t s, off_t off)
 
 
 #if PY_MAJOR_VERSION >= 3
-	Py_buffer buffer;	
+	Py_buffer buffer;
 
 	if(PyObject_CheckBuffer(v)) {
 		PyObject_GetBuffer(v, &buffer, PyBUF_SIMPLE);
@@ -1436,7 +1436,7 @@ Fuse_main(PyObject *self, PyObject *args, PyObject *kw)
 		return(NULL);
 	}
 
- 	fargv = malloc(fargc * sizeof(char *)); 	
+ 	fargv = malloc(fargc * sizeof(char *));
 	if (!fargv)
 		return(PyErr_NoMemory());
 #ifdef FIX_PATH_DECODING
@@ -1448,7 +1448,7 @@ Fuse_main(PyObject *self, PyObject *args, PyObject *kw)
 	if (fargseq) {
 		for (i=0; i < fargc; i++) {
 			PyObject *pa;
-	
+
 			pa = PySequence_GetItem(fargseq, i);
 			if (!PyString_Check(pa)) {
 				Py_DECREF(pa);
@@ -1517,7 +1517,7 @@ Fuse_main(PyObject *self, PyObject *args, PyObject *kw)
 	}
 
 #if FUSE_VERSION >= 26
-	fuse_teardown(fuse, fmp);	
+	fuse_teardown(fuse, fmp);
 #elif FUSE_VERSION >= 22
 	fuse_teardown(fuse, fd, fmp);
 #else
@@ -1528,7 +1528,7 @@ Fuse_main(PyObject *self, PyObject *args, PyObject *kw)
 		PyErr_SetString(Py_FuseError, "service loop failed");
 
 		return (NULL);
-	}		
+	}
 
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -1580,15 +1580,15 @@ FuseGetContext(PyObject *self, PyObject *args)
 		return(NULL);
 
 	num = PyInt_FromLong(fc->uid);
-	PyDict_SetItemString(ret, "uid", num);	
+	PyDict_SetItemString(ret, "uid", num);
 	Py_XDECREF( num );
 
 	num = PyInt_FromLong(fc->gid);
-	PyDict_SetItemString(ret, "gid", num);	
+	PyDict_SetItemString(ret, "gid", num);
 	Py_XDECREF( num );
 
 	num = PyInt_FromLong(fc->pid);
-	PyDict_SetItemString(ret, "pid", num);	
+	PyDict_SetItemString(ret, "pid", num);
 	Py_XDECREF( num );
 
 	return(ret);

--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -407,11 +407,11 @@ releasedir_func(const char *path, struct fuse_file_info *fi)
 	PROLOGUE(
 	  fi_to_py(fi) ?
 #ifdef FIX_PATH_DECODING
-  	  PyObject_CallFunction(releasedir_cb, "O&N", &Path_AsDecodedUnicode, path,
+	  PyObject_CallFunction(releasedir_cb, "O&N", &Path_AsDecodedUnicode, path,
 	                        fi_to_py(fi)) :
 	  PyObject_CallFunction(releasedir_cb, "O&", &Path_AsDecodedUnicode, path)
 #else
-  	  PyObject_CallFunction(releasedir_cb, "sN", path,
+	  PyObject_CallFunction(releasedir_cb, "sN", path,
 	                        fi_to_py(fi)) :
 	  PyObject_CallFunction(releasedir_cb, "s", path)
 #endif
@@ -1436,7 +1436,7 @@ Fuse_main(PyObject *self, PyObject *args, PyObject *kw)
 		return(NULL);
 	}
 
- 	fargv = malloc(fargc * sizeof(char *));
+	fargv = malloc(fargc * sizeof(char *));
 	if (!fargv)
 		return(PyErr_NoMemory());
 #ifdef FIX_PATH_DECODING

--- a/fuseparts/subbedopts.py
+++ b/fuseparts/subbedopts.py
@@ -35,7 +35,7 @@ class SubOptsHive(object):
 
         ra = (list(self.optlist) + sa) or ["(none)"]
         ra.sort()
-        return ra 
+        return ra
 
     def __str__(self):
         return "< opts: " + ", ".join(self._str_core()) + " >"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 import os
 import sys
 
-from fuseparts import __version__ 
+from fuseparts import __version__
 
 classifiers = [ "Development Status :: 5 - Production/Stable",
                 "Intended Audience :: Developers",
@@ -51,7 +51,7 @@ if os.system('pkg-config --exists fuse 2> /dev/null') == 0:
 else:
     if os.system('pkg-config --help 2> /dev/null') == 0:
         print("""pkg-config could not find fuse:
-you might need to adjust PKG_CONFIG_PATH or your 
+you might need to adjust PKG_CONFIG_PATH or your
 FUSE installation is very old (older than 2.1-pre1)""")
 
     else:

--- a/util/voidspace-fusepy.css
+++ b/util/voidspace-fusepy.css
@@ -1,7 +1,7 @@
 /*
 :Authors: Ian Bicking, Michael Foord
 :Contact: fuzzyman@voidspace.org.uk
-:Date: 2005/08/26 
+:Date: 2005/08/26
 :Version: 0.1.0
 :Copyright: This stylesheet has been placed in the public domain.
 
@@ -84,7 +84,7 @@ h1 {
   border: medium solid black;
 }
 
-h1 a.toc-backref, h2 a.toc-backref { 
+h1 a.toc-backref, h2 a.toc-backref {
   color: #ffffff;
 }
 
@@ -99,8 +99,8 @@ h3, h4, h5, h6 {
   color: #000000;
 }
 
-h3 a.toc-backref, h4 a.toc-backref, h5 a.toc-backref, 
-h6 a.toc-backref { 
+h3 a.toc-backref, h4 a.toc-backref, h5 a.toc-backref,
+h6 a.toc-backref {
   color: #000000;
 }
 


### PR DESCRIPTION
Noticed aa0eebb273ddebd94c39e0429f60712f22c047da introduced a traling space, so fixed in all codebase.