### PR TITLE
Add cp310 wheel to CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
   wheel:
     runs-on: ubuntu-20.04
     env:
-      TAGS: cp311-cp311 cp312-cp312
+      TAGS: cp310-cp310 cp311-cp311 cp312-cp312
 
     strategy:
       matrix:


### PR DESCRIPTION
3.10 is used in codespace by default:

```
$ pip install fuse-python
Collecting fuse-python
  Using cached fuse-python-1.0.7.tar.gz (49 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: fuse-python
  Building wheel for fuse-python (pyproject.toml) ... done
  Created wheel for fuse-python: filename=fuse_python-1.0.7-cp310-cp310-linux_x86_64.whl size=100225 sha256=f9dfdf7e38d083720b77a18f82a8b4b1642172f92f13c9e582bd1eefd40869f5
  Stored in directory: /home/codespace/.cache/pip/wheels/0e/09/79/631299a41b121a67d42741483d00de5a494dfad0016fc6bcad
Successfully built fuse-python
Installing collected packages: fuse-python
Successfully installed fuse-python-1.0.7
```

This maybe fixes dependabot env as well:
- https://github.com/libfuse/python-fuse/issues/71

please add built wheel to latest release in pypi.