### PR TITLE
CI: Add workaround for broken py 3.5 in GitHub Actions.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-         - "3.6"
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
          - python-version: "3.5"
            pip-trusted-host: "pypi.python.org pypi.org files.pythonhosted.org"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          env: PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
          - "3.6"
         include:
          - python-version: "3.5"
-           env: PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
+           env: PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.5"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          env: PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"
+        env: PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
          - "3.6"
         include:
          - python-version: "3.5"
-           env: PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"
+           pip-trusted-host: "pypi.python.org pypi.org files.pythonhosted.org"
 
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-        env: PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"
+        env:
+          PIP_TRUSTED_HOST: ${{ matrix.pip-trusted-host }}
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5"]
+        python-version:
+         - "3.6"
+        include:
+         - python-version: "3.5"
+           env: PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Workaround from https://github.com/libfuse/python-fuse/pull/72#issuecomment-2113121158 (from https://github.com/actions/setup-python/issues/866)

For https://github.com/libfuse/python-fuse/pull/72#issuecomment-2114012299

@sdelafond you may squash merge this