### PR TITLE
pull PyCapsule_New() into the PYLOCK() section in poll_func()

### DIFF
--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -1273,8 +1273,13 @@ poll_func(const char *path, struct fuse_file_info *fi,
 {
 	PyObject *pollhandle = Py_None;
 
-	if (ph)
+	if (ph) {
 		pollhandle = PyCapsule_New(ph, pollhandle_name, pollhandle_destructor);
+		if (!pollhandle) {
+			PyErr_Print();
+			goto OUT;
+		}
+	}
 
 #ifdef FIX_PATH_DECODING
 	PROLOGUE(PYO_CALLWITHFI(fi, poll_cb, O&O, &Path_AsDecodedUnicode, path, pollhandle));


### PR DESCRIPTION
If we call PyCapsule_New() from a thread created by libfuse before ensuring the python interpreter is initialized, the thread state will be NULL and the program will crash with SEGFAULT.

As suggested by David Lechner: pull the call to PyCapsule_New() into the PYLOCK() section and open-code the rest of what was previously in the PROLOGUE() macro.

Closes: https://github.com/libfuse/python-fuse/issues/82

@dlech 