### PR TITLE
conditional compilation for macfuse

### DIFF
--- a/fuseparts/_fusemodule.c
+++ b/fuseparts/_fusemodule.c
@@ -923,8 +923,13 @@ flush_func(const char *path)
 	EPILOGUE
 }
 
+#ifdef __APPLE__
+static int
+getxattr_func(const char *path, const char *name, char *value, size_t size, uint32_t position)
+#else
 static int
 getxattr_func(const char *path, const char *name, char *value, size_t size)
+#endif
 {
 #if PY_VERSION_HEX < 0x02050000
 	PROLOGUE( PyObject_CallFunction(getxattr_cb, "ssi", path, name, size) )
@@ -1020,10 +1025,15 @@ listxattr_func(const char *path, char *list, size_t size)
 
 	EPILOGUE
 }
-
+#ifdef __APPLE__
+static int
+setxattr_func(const char *path, const char *name,
+		     const char *value, size_t size, int flags, uint32_t position)
+#else
 static int
 setxattr_func(const char *path, const char *name, const char *value,
               size_t size, int flags)
+#endif
 {
 	PROLOGUE(
 #ifdef FIX_PATH_DECODING


### PR DESCRIPTION
Cannot install python-fuse with macfuse kernel driver per #75 on v1.0.9. Added conditional flags providing extra argument for getxattr and setxattr if on Apple.Tested on Ubuntu, MacOS.

Note - not sure if this package is intended to be compatible with macfuse, but I am using it for a fuse system and developing on MacOS, so this was helpful at least for me. 