### PR TITLE
Build release sdist on 3.13

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install libfuse-dev and pkg-config
         run: sudo apt install -y libfuse-dev pkg-config


### PR DESCRIPTION
Seems good idea to build on latest python stable.

Example run:
- https://github.com/libfuse/python-fuse/actions/runs/12576139042/job/35051928904?pr=90

Refs
- https://github.com/libfuse/python-fuse/pull/81